### PR TITLE
Adding sub-repository support to Mercurial extension's ExportFiles im…

### DIFF
--- a/MercurialProvider.cs
+++ b/MercurialProvider.cs
@@ -190,7 +190,7 @@ namespace Inedo.BuildMasterExtensions.Mercurial
 
         public override void ExportFiles(SourceControlContext context, string targetDirectory)
         {
-            this.ExecuteHgCommand(context.Repository, "archive", "\"" + targetDirectory + "\" -X \".hg*\"");
+            this.ExecuteHgCommand(context.Repository, "archive", "\"" + targetDirectory + "\" -S -X \".hg*\"");
         }
 
         public override object GetCurrentRevision(SourceControlContext context)


### PR DESCRIPTION
…plementation.

When exporting a repository, you should also export its sup-repositories. Sub-repositories are used in Mercurial to share common code between repositories without checking in the same code across repositories and needing an external process to update to the right version of those external dependencies. In our case, we have a build/automation platform shared among almost all our Mercurial repositories that we need BuildMaster to export.
